### PR TITLE
feat: make dev dependencies have a unique branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
           "depTypeList": [
             "devDependencies"
           ],
+          "branchPrefix": "dev-dependency-renovate/",
           "labels": [
             "automerge",
             "dev-dependency",


### PR DESCRIPTION
This change is intended to help differentiate dev dependencies from normal dependencies so we can filter what things run on CI