### PR TITLE
feat: group auto dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,11 @@
           "labels": [
             "dev-dependency"
           ]
-        }
+        },
+        {
+          "packagePatterns": ["auto", "@auto-it"],
+          "groupName": "auto"
+        },
       ]
     }
   },


### PR DESCRIPTION
Our open-source project [Auto](https://intuit.github.io/auto/docs) is built on a Lerna monorepo. Thus, we can optimize the upgrade of any `auto` dependency by grouping them together! This has a benefit that is linear with the number of `@auto-it` plugins being used by a given deployment structure.